### PR TITLE
Fix ddf version specification

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "DodontoF.rb client build package",
   "main": "gulpfile.js",
   "dependencies": {
-    "ddf": ">0.5.6",
+    "ddf": "^0.5.6",
     "browserify": "^14.4.0",
     "gulp": "^3.9.1",
     "gulp-cssnano": "^2.1.2",
@@ -20,8 +20,7 @@
     "store": "^2.0.12",
     "vinyl-buffer": "^1.0.0",
     "watchify": "^3.9.0",
-    "del": "^3.0.0",
-    "store": "^2.0.12"
+    "del": "^3.0.0"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
The latest version of ddf is 0.5.6, so the version specification of ddf should include v0.5.6.