### PR TITLE
LinuxやmacOSでビルドに失敗する問題を解消する

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,15 +1,17 @@
-del = require('del');
-gulp = require('gulp');
-sass = require('gulp-sass');
-pug = require('gulp-pug');
-plumber = require('gulp-plumber');
-notify = require('gulp-notify');
-watchify = require('gulp-watchify');
-cssnano = require('gulp-cssnano');
-rename = require('gulp-rename');
-buffer = require('vinyl-buffer');
-sourcemaps = require('gulp-sourcemaps');
-exec = require('child_process').exec;
+const del = require('del');
+const gulp = require('gulp');
+const sass = require('gulp-sass');
+const pug = require('gulp-pug');
+const plumber = require('gulp-plumber');
+const notify = require('gulp-notify');
+const watchify = require('gulp-watchify');
+const cssnano = require('gulp-cssnano');
+const rename = require('gulp-rename');
+const buffer = require('vinyl-buffer');
+const sourcemaps = require('gulp-sourcemaps');
+const childProcess = require('child_process');
+const fs = require('fs');
+const log = require('fancy-log');
 
 gulp.task('clean', function(){
   del(['build/**/*', '!build/js', '!build/js/lib']);
@@ -76,10 +78,46 @@ gulp.task('browserify', watchify(function(watchify){
   })
 );
 
-gulp.task('build:ddf', ['doc:ddf'], function(){
-  exec('browserify -r ddf -g uglifyify --outfile build/js/lib/ddf.js', function(a,b,c){
-    exec('echo var ddf = require("ddf");>> build/js/lib/ddf.js');
-  });
+const BUILD_DDF = 'build:ddf';
+gulp.task(BUILD_DDF, ['doc:ddf'], () => {
+  const OUT_FILE = 'build/js/lib/ddf.js';
+
+  try {
+    childProcess.execSync(`browserify -r ddf -g uglifyify --outfile ${OUT_FILE}`);
+  } catch (e) {
+    log.error(`${BUILD_DDF}: execSync: ${e.message}`);
+    return;
+  }
+
+  log.info(`${BUILD_DDF}: Browserified ddf`);
+
+  let fd;
+  try {
+    // 出力されたファイルを追記モードで開く
+    fd = fs.openSync(OUT_FILE, 'a');
+  } catch (e) {
+    log.error(`${BUILD_DDF}: openSync: ${e.message}`);
+    return;
+  }
+
+  let success = true;
+  try {
+    // グローバル変数ddfの定義を追記する
+    fs.writeSync(fd, '\nvar ddf = require("ddf");\n');
+  } catch (e) {
+    log.error(`${BUILD_DDF}: writeSync: ${e.message}`);
+    success = false;
+  }
+
+  try {
+    fs.closeSync(fd);
+  } catch (e) {
+    log.error(`${BUILD_DDF}: closeSync: ${e.message}`);
+  }
+
+  if (success) {
+    log.info(`${BUILD_DDF}: Output ${OUT_FILE}`);
+  }
 });
 
 gulp.task('watchify', ['enable-watch-mode', 'enable-debug-mode', 'browserify']);
@@ -90,6 +128,11 @@ gulp.task('watch', ['build:pug', 'build:scss', 'build:asset:local', 'build:ddf',
   gulp.watch(['local/**', 'src/vender/**'], ['build:asset:local']);
 });
 
-gulp.task('doc:ddf', function(){
-  exec('jsdoc -c .jsdoc.json');
+const DOC_DDF = 'doc:ddf';
+gulp.task(DOC_DDF, () => {
+  try {
+    childProcess.execSync('jsdoc -c .jsdoc.json');
+  } catch (e) {
+    log.error(`${DOC_DDF}: execSync: ${e.message}`);
+  }
 });

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "del": "^3.0.0",
     "gulp": "^3.9.1",
     "gulp-cssnano": "^2.1.2",
+    "gulp-notify": "^3.2.0",
     "gulp-plumber": "^1.1.0",
     "gulp-pug": "^3.3.0",
     "gulp-rename": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "DodontoF.rb client build package",
   "main": "gulpfile.js",
   "dependencies": {
-    "ddf": ">0.5.6",
+    "ddf": "^0.5.6",
     "browserify": "^14.4.0",
     "gulp": "^3.9.1",
     "gulp-cssnano": "^2.1.2",
@@ -20,8 +20,7 @@
     "store": "^2.0.12",
     "vinyl-buffer": "^1.0.0",
     "watchify": "^3.9.0",
-    "del": "^3.0.0",
-    "store": "^2.0.12"
+    "del": "^3.0.0"
   },
   "devDependencies": {},
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "DodontoF_html5cli",
   "version": "0.1.4",
   "description": "DodontoF.rb client build package",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/op3kitt/htmlddf.git"
+  },
   "main": "gulpfile.js",
   "dependencies": {
     "ddf": "^0.5.6",

--- a/package.json
+++ b/package.json
@@ -5,24 +5,25 @@
   "main": "gulpfile.js",
   "dependencies": {
     "ddf": "^0.5.6",
+    "msgpack-lite": "^0.1.26",
+    "store": "^2.0.12"
+  },
+  "devDependencies": {
     "browserify": "^14.4.0",
+    "del": "^3.0.0",
     "gulp": "^3.9.1",
     "gulp-cssnano": "^2.1.2",
+    "gulp-plumber": "^1.1.0",
     "gulp-pug": "^3.3.0",
     "gulp-rename": "^1.2.2",
     "gulp-sass": "^3.1.0",
     "gulp-sourcemaps": "^2.6.1",
     "gulp-watchify": "^0.7.0",
-    "gulp-plumber": "^1.1.0",
-    "uglifyify": "^4.0.5",
     "minami": "^1.2.3",
-    "msgpack-lite": "^0.1.26",
-    "store": "^2.0.12",
+    "uglifyify": "^4.0.5",
     "vinyl-buffer": "^1.0.0",
-    "watchify": "^3.9.0",
-    "del": "^3.0.0"
+    "watchify": "^3.9.0"
   },
-  "devDependencies": {},
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "devDependencies": {
     "browserify": "^14.4.0",
     "del": "^3.0.0",
+    "fancy-log": "^1.3.2",
     "gulp": "^3.9.1",
     "gulp-cssnano": "^2.1.2",
     "gulp-notify": "^3.2.0",

--- a/src/pug/_lobby.pug
+++ b/src/pug/_lobby.pug
@@ -2,7 +2,7 @@
   include window/_createPlayRoom
   include window/_loginCheck
   include window/_loginNumber
-  include window/_roomdelete
+  include window/_roomDelete
   #loginMessage_wrap
     #loginMessage
   #playRoomInfos


### PR DESCRIPTION
#3 の続きです。LinuxやmacOSでビルドに失敗する問題を解消します。

主なビルド失敗の原因は以下のとおりです。

* d394bdd: ファイル名の大文字小文字の指定ミス。*nix系では一般に大文字小文字が区別されます。
* ceb0eb6: gulp-notifyが `require` されていましたが、package.jsonに含まれていませんでした。Windowsでも新しい環境では起こるかもしれません。
* 10ec124: リダイレクト演算子 `>>` によるddf.jsへの追記が、シェルの引数解釈の違いによって失敗していました。環境の違いを吸収するには、若干面倒ですが、Node.jsのfsモジュールを使うのが確実です。

これらの変更について、現在Windows環境でのテストができていないため、お手数ですがWindows環境で正常にビルドできることを確認していただければ幸いです。よろしくお願いいたします。